### PR TITLE
Fix CollectorItem.TargetObj has one quote left

### DIFF
--- a/extension-al-object-designer/src/ALObjectParser.ts
+++ b/extension-al-object-designer/src/ALObjectParser.ts
@@ -426,7 +426,7 @@ export class ALObjectParser implements ALObjectDesigner.ObjectParser {
             let TargetType = subsParts[0].split('::')[1];
             let TargetObj = '';
             if (subsParts[1].indexOf('::') != -1) {
-                TargetObj = subsParts[1].split('::')[1].replace(/\"/, '').trim();
+                TargetObj = subsParts[1].split('::')[1].replace(/\"/g, '').trim();
             } else {
                 TargetObj = subsParts[1];
             }


### PR DESCRIPTION
Hi Marton,

the TargetObject of CollectorItems has mostly a quote left at the end of the string.
Major change from me, isn't it? ;)

Best regards
David