### PR TITLE
Update Regex getObjectHeadersFromText

### DIFF
--- a/extension-al-object-designer/src/utils.ts
+++ b/extension-al-object-designer/src/utils.ts
@@ -154,9 +154,58 @@ export async function getObjectHeaders(filePath: string) {
     return result;
 }
 
+/*
+// Regex Test
+import { getObjectHeadersFromText } from './utils';
+
+describe('getObjectHeadersFromText', () => {
+    it('should extract valid object headers from file content', () => {
+        const fileContent = `
+            codeunit 50100 MyCodeunit
+            pageextension 70000 MyPageExtension
+            table 12345 MyTable
+            invalidObjectType 123 InvalidObject
+        `;
+
+        const expectedHeaders = [
+            'codeunit 50100 MyCodeunit',
+            'pageextension 70000 MyPageExtension',
+            'table 12345 MyTable'
+        ];
+
+        const result = getObjectHeadersFromText(fileContent);
+
+        expect(result).toEqual(expectedHeaders);
+    });
+
+    it('should return an empty array if no valid object headers are present', () => {
+        const fileContent = `
+            invalidObjectType 123 InvalidObject
+            random text here
+        `;
+
+        const expectedHeaders: string[] = [];
+
+        const result = getObjectHeadersFromText(fileContent);
+
+        expect(result).toEqual(expectedHeaders);
+    });
+
+    it('should handle empty input gracefully', () => {
+        const fileContent = ``;
+
+        const expectedHeaders: string[] = [];
+
+        const result = getObjectHeadersFromText(fileContent);
+
+        expect(result).toEqual(expectedHeaders);
+    });
+});
+*/
+
 export function getObjectHeadersFromText(fileContent: string) {
     //let pattern = /([a-z]+)\s([0-9]+|.*?)\s?(.*)/gm;
-    let pattern = /\b^(codeunit|page|pageextension|pagecustomization|dotnet|enum|interface|enumextension|query|report|table|tableextension|xmlport|profile|controladdin)\s([0-9]+|.*?)\s?(.*)/gmi;
+    let pattern = /^(codeunit|page|pageextension|pagecustomization|dotnet|enum|interface|enumextension|query|report|table|tableextension|xmlport|profile|controladdin)\s([0-9]+|.*?)\s?(.*)/gmi;
     let matches = getAllMatches(pattern, fileContent);
 
     let result = matches.map(m => m[0]);


### PR DESCRIPTION
This pattern is used to match specific object headers in the getObjectHeadersFromText function. However, there might be an issue with the regular expression itself or how it is applied to the input fileContent. Here are some possible areas of concern:

\b^ Combination:

The \b (word boundary) followed by ^ (start of line) may not behave as intended. You likely need just ^ to match the start of a line. Matching Logic:

Ensure the pattern correctly captures the intended object types (like codeunit, page, etc.) and their respective properties from the file content. Global Modifier (g):

Check if the g modifier is suitable for your use case. If the pattern is used to find all matches, it is fine; otherwise, it might cause unexpected results. Input Data:

If the input data (fileContent) doesn't match the expected format, the regular expression might fail to produce the desired results.